### PR TITLE
build: Allow any host header for webpack devserver

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,6 +26,7 @@ module.exports = (env, argv) => {
         key: path.resolve(os.homedir(), '.localhost-ssl/localhost.key'),
         cert: path.resolve(os.homedir(), '.localhost-ssl/localhost.crt'),
       },
+      allowedHosts: "all"
     },
     devtool: devMode ? 'eval-cheap-module-source-map' : 'source-map',
     entry: './src/index.tsx',


### PR DESCRIPTION
This allows for webpack to serve tunneled requests where the hostname isn't localhost