### PR TITLE
fix: Added rerender of heirarchy when window resizes [PT-184835640]

### DIFF
--- a/src/components/hierarchy.tsx
+++ b/src/components/hierarchy.tsx
@@ -5,6 +5,7 @@ import { Menu } from "./menu";
 import { DndContext, DragEndEvent, closestCenter } from "@dnd-kit/core";
 import { SortableContext, verticalListSortingStrategy, useSortable, arrayMove} from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import { useWindowResized } from "../hooks/useWindowResized";
 
 import css from "./hierarchy.scss";
 
@@ -139,6 +140,10 @@ const Collection = (props: CollectionProps) => {
 
 export const Hierarchy = (props: IProps) => {
   const {selectedDataSet, dataSets, collections, handleSelectDataSet, handleUpdateAttributePosition} = props;
+
+  // this will ensure that the component re-renders if the plugin window resizes - it keeps a local state variable
+  // of the last resize time
+  useWindowResized();
 
   const renderHeirarchy = () => {
     const numCollections = collections.length;

--- a/src/hooks/useWindowResized.tsx
+++ b/src/hooks/useWindowResized.tsx
@@ -1,0 +1,17 @@
+import { useState, useEffect } from "react";
+
+export const useWindowResized = (): number|undefined => {
+
+  const [resizedAt, setResizedAt] = useState<number|undefined>(undefined);
+
+  useEffect(() => {
+    const handleResize = () => setResizedAt(Date.now);
+
+    window.addEventListener("resize", handleResize);
+    handleResize();
+
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return resizedAt;
+};


### PR DESCRIPTION
This uses a hook that keeps the last window resize time in its internal state which will trigger a re-render of the component.