### PR TITLE
ci: fix s3 symlink destination filename

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ env:
   BUCKET: models-resources
   PREFIX: multidata-plugin
   SRC_FILE: index-top.html
-  DEST_FILE: index-demo.html
+  DEST_FILE: index.html
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This should allow loading the plugin from the base sub-domain URL. See description of story PT-186485698 for more details.