### PR TITLE
Fix dropdown icon issue that was causing dragging bug. (PT-188114776)

### DIFF
--- a/src/assets/dropdown-arrow-icon.svg
+++ b/src/assets/dropdown-arrow-icon.svg
@@ -1,6 +1,5 @@
-<svg width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+<svg width="20" height="10" viewBox="0 0 20 10" xmlns="http://www.w3.org/2000/svg">
     <g fill="none" fill-rule="evenodd">
-        <path d="M0 0h20v20H0z"/>
-        <path fill="#000000" fill-rule="nonzero" d="M5.833 8.333 10 12.5l4.167-4.167z"/>
+      <path fill="#000000" d="M0 0 L10 10 L20 0 Z"/>
     </g>
 </svg>

--- a/src/components/draggable-table-tags.tsx
+++ b/src/components/draggable-table-tags.tsx
@@ -99,11 +99,17 @@ export const DraggagleTableHeader: React.FC<DraggagleTableHeaderProps> = ({colle
         onMouseLeave={() => setShowDropdownIcon(false)}
         onClick={handleShowHeaderMenu}
       >
-        {children}
-        {showDropdownIcon &&
-          <DropdownIcon onClick={handleShowHeaderMenu}
-                        style={{position: "absolute", right: 0, top: -2}}/>
-        }
+        <div className={css.thChildContainer}>
+          <div>{children}</div>
+          {showDropdownIcon &&
+            <div className={css.dropdownIcon}>
+              <DropdownIcon
+                onClick={handleShowHeaderMenu}
+                className={css.dropdownIcon}
+              />
+            </div>
+          }
+        </div>
       </th>
       { showHeaderMenu && tableContainer && headerPos &&
           createPortal(

--- a/src/components/tables.scss
+++ b/src/components/tables.scss
@@ -280,3 +280,21 @@ table.draggableTableContainer {
     padding: 5px;
   }
 }
+
+.thChildContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 15px;
+  width: 100%;
+  gap: 5px;
+  .dropdownIcon {
+    &:hover {
+      cursor: pointer;
+    }
+    svg {
+      width: 10px;
+    }
+  }
+}


### PR DESCRIPTION
Because the dropdown icon was positioned absolutely, it was appearing only at the top right corner of the app. When the user went to drag a table header, it caused it to look as though the whole area up to where the dropdown icon was positioned was being dragged along with it. 

Here's an screenshot:
<img width="761" alt="Screenshot 2024-08-21 at 4 19 58 PM" src="https://github.com/user-attachments/assets/924f1586-8be2-4fad-a105-04d6793aa3ec">


The changes made assume that the dropdown icon should actually appear within the table header. 