### PR TITLE
188363563 Display Formula Editor

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -14,7 +14,7 @@ function App() {
          handleAddCollection, handleAddAttribute, handleSelectSelf,
          updateTitle, selectCODAPCases, listenForSelectionChanges,
          handleCreateCollectionFromAttribute, handleSetCollections,
-         handleSortAttribute, editCaseValue, renameAttribute } = useCodapState();
+         editCaseValue, renameAttribute } = useCodapState();
   const collections = collectionsModel.collections;
 
   useEffect(() => {
@@ -109,7 +109,6 @@ function App() {
           handleUpdateAttributePosition={handleUpdateAttributePosition}
           handleCreateCollectionFromAttribute={handleCreateCollectionFromAttribute}
           editCaseValue={editCaseValue}
-          handleSortAttribute={handleSortAttribute}
           handleAddAttribute={handleAddAttribute}
           renameAttribute={renameAttribute}
         />

--- a/src/components/nested-table-view/common/draggable-table-tags.tsx
+++ b/src/components/nested-table-view/common/draggable-table-tags.tsx
@@ -5,7 +5,9 @@ import { observer } from "mobx-react-lite";
 import { getAttribute, IResult } from "@concord-consortium/codap-plugin-api";
 import { useDraggableTableContext, Side } from "../../../hooks/useDraggableTable";
 import { useTableTopScrollTopContext } from "../../../hooks/useTableScrollTop";
-import { endCodapDrag, getCollectionById, moveCodapDrag, startCodapDrag } from "../../../utils/apiHelpers";
+import {
+  endCodapDrag, getCollectionById, moveCodapDrag, sortAttribute, startCodapDrag
+} from "../../../utils/apiHelpers";
 import { getDisplayValue } from "../../../utils/utils";
 import {
   ICollection, ICollections, IDndData, IProcessedCaseObj, isCollectionData, PropsWithChildren
@@ -47,7 +49,6 @@ interface DraggableTableHeaderProps {
   colSpan?: number;
   dataSetName: string;
   dataSetTitle: string;
-  handleSortAttribute: (dataSetName: string, attributeId: number, isDescending: boolean) => void;
   isParent?: boolean;
   editableHasFocus?: boolean;
   attrId?: number;
@@ -56,7 +57,7 @@ interface DraggableTableHeaderProps {
 
 export const DraggableTableHeader: React.FC<PropsWithChildren<DraggableTableHeaderProps>> =
   observer(function DraggagleTableHeader(props) {
-    const {collectionId, attrTitle, caseId, dataSetName, editableHasFocus, children, handleSortAttribute,
+    const {collectionId, attrTitle, caseId, dataSetName, editableHasFocus, children,
        isParent, attrId, renameAttribute, colSpan} = props;
 
     // Manage header dropdown menus
@@ -93,7 +94,7 @@ export const DraggableTableHeader: React.FC<PropsWithChildren<DraggableTableHead
       const isDescending = e.target.value === "desc";
       const collectionName = await getCollectionById(dataSetName, collectionId);
       const attribute = (await getAttribute(dataSetName, collectionName, attrTitle)).values;
-      handleSortAttribute(dataSetName, attribute.id, isDescending);
+      sortAttribute(dataSetName, attribute.id, isDescending);
       setShowHeaderMenu(false);
     };
 

--- a/src/components/nested-table-view/common/draggable-table-tags.tsx
+++ b/src/components/nested-table-view/common/draggable-table-tags.tsx
@@ -95,10 +95,12 @@ export const DraggableTableHeader: React.FC<PropsWithChildren<DraggableTableHead
 
     const handleSortAttribute = (isDescending = false) => {
       sortAttribute(dataSetName, attrTitle, isDescending);
+      setShowHeaderMenu(false);
     };
 
     const handleDisplayFormulaEditor = () => {
       displayFormulaEditor(dataSetName, attrTitle);
+      setShowHeaderMenu(false);
     };
 
     // Manage synthetic drag in Codap via API requests
@@ -221,8 +223,8 @@ export const DraggableTableHeader: React.FC<PropsWithChildren<DraggableTableHead
         { showHeaderMenu && tableContainer && headerPos &&
             createPortal(
               <div className={css.headerMenu} ref={headerMenuRef}
-                    style={{left: headerPos?.left + 5, top: headerPos?.bottom  + scrollY}}>
-                <button onClick={handleDisplayFormulaEditor}>Edit Formula</button>
+                    style={{left: headerPos?.left + 5 + scrollX, top: headerPos?.bottom  + scrollY}}>
+                <button onClick={handleDisplayFormulaEditor}>Edit Formula...</button>
                 <button onClick={() => handleSortAttribute()}>Sort Ascending (A➞Z, 0➞9)</button>
                 <button onClick={() => handleSortAttribute(true)}>Sort Descending (Z➞A, 9➞0)</button>
               </div>,

--- a/src/components/nested-table-view/common/draggable-table-tags.tsx
+++ b/src/components/nested-table-view/common/draggable-table-tags.tsx
@@ -2,11 +2,11 @@ import { Over, useDndContext, useDndMonitor, useDraggable, useDroppable } from "
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { observer } from "mobx-react-lite";
-import { getAttribute, IResult } from "@concord-consortium/codap-plugin-api";
+import { IResult } from "@concord-consortium/codap-plugin-api";
 import { useDraggableTableContext, Side } from "../../../hooks/useDraggableTable";
 import { useTableTopScrollTopContext } from "../../../hooks/useTableScrollTop";
 import {
-  endCodapDrag, getCollectionById, moveCodapDrag, sortAttribute, startCodapDrag
+  displayFormulaEditor, endCodapDrag, moveCodapDrag, sortAttribute, startCodapDrag
 } from "../../../utils/apiHelpers";
 import { getDisplayValue } from "../../../utils/utils";
 import {
@@ -90,12 +90,12 @@ export const DraggableTableHeader: React.FC<PropsWithChildren<DraggableTableHead
       setShowHeaderMenu(!showHeaderMenu);
     };
 
-    const handleSortAttr = async (e: React.ChangeEvent<HTMLSelectElement>) => {
-      const isDescending = e.target.value === "desc";
-      const collectionName = await getCollectionById(dataSetName, collectionId);
-      const attribute = (await getAttribute(dataSetName, collectionName, attrTitle)).values;
-      sortAttribute(dataSetName, attribute.id, isDescending);
-      setShowHeaderMenu(false);
+    const handleSortAttribute = (isDescending = false) => {
+      sortAttribute(dataSetName, attrTitle, isDescending);
+    };
+
+    const handleDisplayFormulaEditor = () => {
+      displayFormulaEditor(dataSetName, attrTitle);
     };
 
     // Manage synthetic drag in Codap via API requests
@@ -219,10 +219,9 @@ export const DraggableTableHeader: React.FC<PropsWithChildren<DraggableTableHead
             createPortal(
               <div className={css.headerMenu} ref={headerMenuRef}
                     style={{left: headerPos?.left + 5, top: headerPos?.bottom  + scrollY}}>
-                  <select className={css.headerMenuSelect} size={2} onChange={handleSortAttr}>
-                      <option value="asc">Sort Ascending (A➞Z, 0➞9)</option>
-                      <option value="desc">Sort Descending (Z➞A, 9➞0)</option>
-                  </select>
+                <button onClick={handleDisplayFormulaEditor}>Edit Formula</button>
+                <button onClick={() => handleSortAttribute()}>Sort Ascending (A➞Z, 0➞9)</button>
+                <button onClick={() => handleSortAttribute(true)}>Sort Descending (Z➞A, 9➞0)</button>
               </div>,
               tableContainer
             )

--- a/src/components/nested-table-view/common/draggable-table-tags.tsx
+++ b/src/components/nested-table-view/common/draggable-table-tags.tsx
@@ -70,7 +70,10 @@ export const DraggableTableHeader: React.FC<PropsWithChildren<DraggableTableHead
 
     useEffect(() => {
       const handleClickOutside = (e: MouseEvent) => {
-        if (headerMenuRef.current && !headerMenuRef.current.contains(e.target as Node)) {
+        if (headerMenuRef.current &&
+          !headerMenuRef.current.contains(e.target as Node) &&
+          !headerRef.current?.contains(e.target as Node)
+        ) {
           setShowHeaderMenu(false);
         }
       };

--- a/src/components/nested-table-view/common/draggable-table-tags.tsx
+++ b/src/components/nested-table-view/common/draggable-table-tags.tsx
@@ -200,9 +200,9 @@ export const DraggableTableHeader: React.FC<PropsWithChildren<DraggableTableHead
           onClick={handleShowHeaderMenu}
         >
           <div className={`${css.thChildContainer} ${isParent ? css.isParent : ""}`}>
+            <button className={css.dropdownIconContainer} onClick={handleShowHeaderMenu} />
             <button
-              onMouseEnter={() => setShowDropdownIcon(true)}
-              onMouseLeave={() => setShowDropdownIcon(false)}
+              className={css.attributeTitleContainer}
               onClick={handleShowHeaderMenu}
             >
               {attrId && editableHasFocus
@@ -215,7 +215,7 @@ export const DraggableTableHeader: React.FC<PropsWithChildren<DraggableTableHead
                   />
                 : children}
             </button>
-            <button className={css.dropdownIcon} onClick={handleShowHeaderMenu}>
+            <button className={css.dropdownIconContainer} onClick={handleShowHeaderMenu}>
               {showDropdownIcon && <DropdownIcon className={css.dropdownIcon} />}
             </button>
           </div>

--- a/src/components/nested-table-view/common/table-headers.tsx
+++ b/src/components/nested-table-view/common/table-headers.tsx
@@ -13,7 +13,6 @@ interface ITableHeaders {
   attrId?: number;
   editableHasFocus?: boolean;
   selectedDataSet: IDataSet;
-  handleSortAttribute: (dataSetName: string, attributeId: number, isDescending: boolean) => void;
   renameAttribute: (collectionName: string, attrId: number, oldName: string, newName: string) => Promise<void>;
 }
 
@@ -27,7 +26,6 @@ export const TableHeaders: React.FC<ITableHeaders> = ({
   attrId,
   editableHasFocus,
   selectedDataSet,
-  handleSortAttribute,
   renameAttribute
 }) => {
   const caseValuesKeys = [...values.keys()];
@@ -48,7 +46,6 @@ export const TableHeaders: React.FC<ITableHeaders> = ({
               attrId={attrId}
               editableHasFocus={editableHasFocus && isEditable}
               renameAttribute={renameAttribute}
-              handleSortAttribute={handleSortAttribute}
             >
               {key}
             </DraggableTableHeader>

--- a/src/components/nested-table-view/common/tables.scss
+++ b/src/components/nested-table-view/common/tables.scss
@@ -294,6 +294,7 @@ table.draggableTableContainer {
     background-color: transparent;
     border: none;
     cursor: pointer;
+    white-space: nowrap;
 
     &:hover {
       color: #666;

--- a/src/components/nested-table-view/common/tables.scss
+++ b/src/components/nested-table-view/common/tables.scss
@@ -271,6 +271,7 @@ table.draggableTableContainer {
 }
 
 .draggable {
+  cursor: pointer;
   padding-right: 17px;
   padding-left: 15px;
   box-sizing: border-box;
@@ -310,19 +311,25 @@ table.draggableTableContainer {
   justify-content: center;
   width: 100%;
   height: 15px;
-  gap: 5px;
 
   button {
     all: unset;
     cursor: pointer;
   }
 
-  .dropdownIcon {
-    &:hover {
-      cursor: pointer;
-    }
-    svg {
+  .attributeTitleContainer {
+    padding: 0 5px;
+  }
+
+  .dropdownIconContainer {
+    width: 10px;
+
+    .dropdownIcon {
       width: 10px;
+
+      &:hover {
+        cursor: pointer;
+      }
     }
   }
 

--- a/src/components/nested-table-view/common/tables.scss
+++ b/src/components/nested-table-view/common/tables.scss
@@ -281,11 +281,23 @@ table.draggableTableContainer {
 }
 
 .headerMenu {
-  position: absolute;
+  align-items: start;
+  background-color: white;
   box-shadow: 0 1px 20px 0 rgba(0, 0, 0, 0.25);
+  display: flex;
+  flex-direction: column;
+  padding: 5px;
+  position: absolute;
   z-index: 50;
-  .headerMenuSelect {
-    padding: 5px;
+
+  button {
+    background-color: transparent;
+    border: none;
+    cursor: pointer;
+
+    &:hover {
+      color: #666;
+    }
   }
 }
 

--- a/src/components/nested-table-view/common/tables.scss
+++ b/src/components/nested-table-view/common/tables.scss
@@ -294,7 +294,9 @@ table.draggableTableContainer {
     background-color: transparent;
     border: none;
     cursor: pointer;
+    text-align: left;
     white-space: nowrap;
+    width: 100%;
 
     &:hover {
       color: #666;

--- a/src/components/nested-table-view/flat/flat-table.tsx
+++ b/src/components/nested-table-view/flat/flat-table.tsx
@@ -12,11 +12,10 @@ import css from "../common/tables.scss";
 interface IFlatProps extends ITableProps {
   cases: IProcessedCaseObj[]
   editCaseValue: (newValue: string, cCase: IProcessedCaseObj, attrTitle: string) => Promise<IResult | undefined>;
-  handleSortAttribute: (context: string, attrId: number, isDescending: boolean) => void;
 }
 
 export const FlatTable = observer(function FlatTable(props: IFlatProps) {
-  const {selectedDataSet, collectionsModel, collectionClasses, handleSortAttribute, showHeaders,
+  const {selectedDataSet, collectionsModel, collectionClasses, showHeaders,
          editCaseValue, renameAttribute, handleAddAttribute } = props;
   const { collections, attrVisibilities, attrPrecisions, attrTypes } = collectionsModel;
   const collection = collectionsModel.collections[0];
@@ -53,7 +52,6 @@ export const FlatTable = observer(function FlatTable(props: IFlatProps) {
                        dataSetName={selectedDataSet.name}
                        dataSetTitle={selectedDataSet.title}
                        editableHasFocus={isEditable}
-                       handleSortAttribute={handleSortAttribute}
                        renameAttribute={renameAttribute}
                      >
                       {attr.title}

--- a/src/components/nested-table-view/landscape/landscape-table.tsx
+++ b/src/components/nested-table-view/landscape/landscape-table.tsx
@@ -9,7 +9,7 @@ import css from "../common/tables.scss";
 
 export const LandscapeTable = observer(function LandscapeView(props: ITableProps) {
   const { showHeaders, collectionClasses, getClassName, selectedDataSet, collectionsModel, getValueLength,
-    paddingStyle, handleSortAttribute, renameAttribute, editCaseValue } = props;
+    paddingStyle, renameAttribute, editCaseValue } = props;
   const { collections, attrPrecisions, attrTypes, attrVisibilities } = collectionsModel;
 
   const renderNestedTable = (parentColl: ICollection) => {
@@ -36,7 +36,6 @@ export const LandscapeTable = observer(function LandscapeView(props: ITableProps
                 values={values}
                 attrVisibilities={attrVisibilities}
                 selectedDataSet={selectedDataSet}
-                handleSortAttribute={handleSortAttribute}
                 renameAttribute={renameAttribute}
               />
             );
@@ -100,7 +99,6 @@ export const LandscapeTable = observer(function LandscapeView(props: ITableProps
                 values={values}
                 attrVisibilities={attrVisibilities}
                 selectedDataSet={selectedDataSet}
-                handleSortAttribute={handleSortAttribute}
                 renameAttribute={renameAttribute}
               />
             </tr>
@@ -155,7 +153,6 @@ export const LandscapeTable = observer(function LandscapeView(props: ITableProps
             colSpan={firstRowValues.length}
             dataSetName={selectedDataSet.name}
             dataSetTitle={selectedDataSet.title}
-            handleSortAttribute={handleSortAttribute}
             renameAttribute={renameAttribute}
           >
             {selectedDataSet.name}

--- a/src/components/nested-table-view/nested-table.tsx
+++ b/src/components/nested-table-view/nested-table.tsx
@@ -28,7 +28,6 @@ interface IProps {
   handleShowComponent: () => void;
   handleUpdateAttributePosition: (collection: ICollection, attrName: string, newPosition: number) => void
   handleCreateCollectionFromAttribute: (collection: ICollection, attr: any, parent: number|string) => Promise<void>
-  handleSortAttribute: (context: string, attrId: number, isDescending: boolean) => void;
   editCaseValue: (newValue: string, caseObj: IProcessedCaseObj, attrTitle: string) => Promise<IResult | undefined>;
   handleAddAttribute: (collection: ICollection, attrName: string, tableIndex: number) => Promise<void>;
   renameAttribute: (collectionName: string, attrId: number, oldName: string, newName: string) => Promise<void>;
@@ -38,7 +37,7 @@ export const NestedTable = observer(function NestedTable(props: IProps) {
   const {selectedDataSet, dataSets, collectionsModel, cases, interactiveState,
          handleSelectDataSet, updateInteractiveState, handleShowComponent,
          handleUpdateAttributePosition, handleCreateCollectionFromAttribute,
-         handleSortAttribute, editCaseValue, renameAttribute, handleAddAttribute} = props;
+         editCaseValue, renameAttribute, handleAddAttribute} = props;
   const [collectionClasses, setCollectionClasses] = useState<ICollectionClass[]>([]);
   const [paddingStyle, setPaddingStyle] = useState<Record<string, string>>({padding: "0px"});
   const collections = collectionsModel.collections;
@@ -110,7 +109,7 @@ export const NestedTable = observer(function NestedTable(props: IProps) {
     const isNoHierarchy = collections.length === 1;
     const classesExist = collectionClasses.length > 0;
     const tableProps = {showHeaders: interactiveState.showHeaders, collectionClasses, collectionsModel,
-      selectedDataSet, getClassName, getValueLength, paddingStyle, editCaseValue, handleSortAttribute,
+      selectedDataSet, getClassName, getValueLength, paddingStyle, editCaseValue,
       dataSetName: selectedDataSet.name, renameAttribute, handleAddAttribute,
       activeTableIndex: interactiveState.activeTableIndex};
     const flatProps = {...tableProps, cases};

--- a/src/components/nested-table-view/portrait/portrait-table-row.tsx
+++ b/src/components/nested-table-view/portrait/portrait-table-row.tsx
@@ -15,7 +15,7 @@ export type PortraitTableRowProps = {
 
 export const PortraitTableRow = observer(function PortraitTableRow(props: PortraitTableRowProps) {
   const { paddingStyle, showHeaders, getClassName, caseObj, index, isParent, parentLevel = 0, dataSetName,
-    handleAddAttribute, collectionsModel, handleSortAttribute, renameAttribute, editCaseValue,
+    handleAddAttribute, collectionsModel, renameAttribute, editCaseValue,
     selectedDataSet, getsFocusOnAddAttr, tableIndex } = props;
   const { collections, attrVisibilities, attrPrecisions, attrTypes } = collectionsModel;
   const collectionId = caseObj.collection.id;
@@ -53,7 +53,6 @@ export const PortraitTableRow = observer(function PortraitTableRow(props: Portra
               attrId={id}
               editableHasFocus={getsFocusOnAddAttr}
               selectedDataSet={selectedDataSet}
-              handleSortAttribute={handleSortAttribute}
               renameAttribute={renameAttribute}
             />
             {showHeaders ? (
@@ -110,7 +109,6 @@ export const PortraitTableRow = observer(function PortraitTableRow(props: Portra
                               attrId={child.id}
                               editableHasFocus={getsFocusOnAddAttr}
                               selectedDataSet={selectedDataSet}
-                              handleSortAttribute={handleSortAttribute}
                               renameAttribute={renameAttribute}
                             />
                           </tr>

--- a/src/hooks/useCodapState.tsx
+++ b/src/hooks/useCodapState.tsx
@@ -18,7 +18,7 @@ import {
 } from "@concord-consortium/codap-plugin-api";
 import { runInAction } from "mobx";
 import { applySnapshot, unprotect } from "mobx-state-tree";
-import { getCases, getCollectionById, getDataSetCollections, sortAttribute } from "../utils/apiHelpers";
+import { getCases, getCollectionById, getDataSetCollections } from "../utils/apiHelpers";
 import { ICollection, IDataSet, IProcessedCaseObj } from "../types";
 import { DataSetsModel, DataSetsModelType } from "../models/datasets";
 import { CollectionsModel, CollectionsModelSnapshot, CollectionsModelType } from "../models/collections";
@@ -227,10 +227,6 @@ export const useCodapState = () => {
       }
     };
 
-  const handleSortAttribute = async (context: string, attrId: number, isDescending: boolean) => {
-    sortAttribute(context, attrId, isDescending);
-  };
-
   const handleAddAttribute = async (collection: ICollection, attrName: string, tableIndex=0) => {
     if (!selectedDataSet) return;
 
@@ -354,7 +350,6 @@ export const useCodapState = () => {
     connected,
     handleUpdateAttributePosition,
     handleAddCollection,
-    handleSortAttribute,
     handleAddAttribute,
     updateTitle,
     selectCODAPCases,

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,7 +79,6 @@ export interface ITableProps {
   paddingStyle: Record<string, string>;
   tableIndex?: number;
   activeTableIndex?: number;
-  handleSortAttribute: (context: string, attrId: number, isDescending: boolean) => void;
   handleAddAttribute: (collection: ICollection, attrName: string, tableIndex: number) => Promise<void>;
   renameAttribute: (collectionName: string, attrId: number, oldName: string, newName: string) => Promise<void>;
 }
@@ -123,7 +122,6 @@ export type CodapState = {
   handleSelectDataSet: (name: string) => void;
   handleSelectSelf: () => Promise<void>;
   handleSetCollections: (collections: ICollections) => void;
-  handleSortAttribute: (context: string, attrId: number, isDescending: boolean) => Promise<void>;
   handleUpdateAttributePosition: (coll: ICollection, attrName: string, position: number) => Promise<void>;
   handleUpdateCollections: () => Promise<void>;
   init: () => Promise<void>;

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -57,13 +57,23 @@ export const getCollectionById = async (selectedDataSetName: string, collId: num
   return collectionName;
 };
 
-export const sortAttribute = async (context: string, attrId: number, isDescending: boolean) => {
+export function displayFormulaEditor(context: string, attrTitle: string) {
+  codapInterface.sendRequest({
+    "action": "notify",
+    "resource": `dataContext[${context}].attribute[${attrTitle}]`,
+    "values": {
+      "request": "formulaEditor"
+    }
+  });
+}
+
+export const sortAttribute = async (context: string, attrTitle: string, isDescending: boolean) => {
   await codapInterface.sendRequest({
     "action": "update",
     "resource": `dataContext[${context}]`,
     "values": {
       "sort": {
-        attr: attrId,
+        attr: attrTitle,
         isDescending,
       }
     }


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/188363563

This PR adds a menu item to the Nested Table attribute menu that pulls up the edit formula modal in Codap.

Additionally, there are several other improvements:
- `handleSortAttribute` has been removed from `useCodapState`, which eliminates the need to prop-drill it through many layers of components.
- `sortAttribute` now takes an `attributeTitle` instead of an `attributeId`, eliminating the need for two API requests in `DraggableTableHeader.handleSortAttribute`.
- The `DraggableTableHeader` background click no longer triggers when clicking the attribute header. This was causing a bug where clicking on the header when the menu was open would close the menu and then immediately open it again.
- The `DraggableTableHeader` menu has been improved in a number of ways:
  - It was converted from a `select` with `options` to a series of `buttons`.
  - A positioning bug has been fixed by adjusting the x positioning by `scrollX`.
  - The styling of this menu was improved.
  
This work can be tested with this Codap link: https://codap3.concord.org/branch/v3-di-formula-editor-request/#file=examples:Mammals
And this Multidata link: https://models-resources.concord.org/multidata-plugin/branch/display-formula-editor/index.html