### PR TITLE
Fixes bug for assigning precisions to numbers.

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -6,7 +6,7 @@ export const getDisplayValue = (cellValue: string | number, attrTitle: string,
     const isAttrNumberType = attrTypes[attrTitle] === "numeric";
     const cellHasValue = cellValue !== "";
     const isValueNumberType = typeof cellValue === "number";
-    const parsedValue: number = typeof cellValue === "string" ? parseFloat(cellValue) : NaN;
+    const parsedValue: number = typeof cellValue === "string" ? parseFloat(cellValue) : cellValue;
     const isValueNumber = !isNaN(parsedValue);
     const hasPrecision = precisions[attrTitle] !== undefined;
     const defaultValue: string | number = cellValue;


### PR DESCRIPTION
parsedValue was returning NaN if the cellValue is a number so isValuedNumber is NaN when cellValue is a number. 
This changes the parsedValue to the cellValue is cellValus is a number