### PR TITLE
feat: table updates when cases or items are created

### DIFF
--- a/src/hooks/useCodapState.tsx
+++ b/src/hooks/useCodapState.tsx
@@ -105,35 +105,27 @@ export const useCodapState = () => {
       if (iMessage.resource === `dataContextChangeNotice[${selectedDataSetName}]`) {
         const theValues = iMessage.values;
         switch (theValues.operation) {
-          case `selectCases`:
-          case `updateCases`:
-          // case `moveCases`:
-              refreshDataSetInfo();
-              break;
-          case `updateCollection`:
-          case `createCollection`:
-          case `deleteCollection`:
-          case `moveAttribute`:
-          case `deleteAttributes` :
-          case `createAttributes` :
-          case `updateAttributes`:
-          case `hideAttributes`:
-          case `showAttributes`:
-          case `unhideAttributes`:
-              refreshDataSetInfo();
-              break;
-          case `updateDataContext`:       //  includes renaming dataset, so we have to redo the menu
-              refreshDataSetInfo();
-              break;
-          case `moveCases`:
-              handleMoveCases();
-              break;
+          case "updateDataContext":       //  includes renaming dataset, so we have to redo the menu
+          case "createCollection":
+          case "updateCollection":
+          case "deleteCollection":
+          case "createAttributes":
+          case "moveAttribute":
+          case "updateAttributes":
+          case "deleteAttributes":
+          case "hideAttributes":
+          case "showAttributes":
+          case "unhideAttributes":
           case "createCases":
           case "createItems":
-              refreshDataSetInfo();
-              break;
+          case "moveCases":
+          case "selectCases":
+          case "updateCases":
+            // TODO: consider throttling
+            refreshDataSetInfo();
+            break;
           default:
-              break;
+            break;
         }
       }
     };
@@ -153,10 +145,6 @@ export const useCodapState = () => {
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedDataSet, selectedDataSetName]);
-
-  const handleMoveCases = () => {
-    updateCollections();
-  };
 
   const handleSetCollections = useCallback((colls: ICollection[]) => {
     const newCollectionModels = colls.map((coll: ICollection) => {

--- a/src/hooks/useCodapState.tsx
+++ b/src/hooks/useCodapState.tsx
@@ -130,6 +130,7 @@ export const useCodapState = () => {
               break;
           case "createCases":
           case "createItems":
+              refreshDataSetInfo();
               break;
           default:
               break;


### PR DESCRIPTION
[[PT-188838144]](https://www.pivotaltracker.com/n/projects/2441242/stories/188838144)

I can find no evidence that this ever worked. The code for handling `createCases` and `createItems` requests looks like this:

```
          case "createCases":
          case "createItems":
              break;
```

and has since its introduction in PR #2.

>Strangely, it does seem to still work with the [sensor interactive](https://codap3.concord.org/sensor-interactive/).

This appears to be because the sensor-interactive sends out a `createAttributes` request in addition to a `createItems` request, and the `createAttributes` request _is_ handled by the multidata plugin.

Note that the fix here isn't necessarily the right/best fix. It could result in excessive calls to `refreshDataSetInfo()`, for instance, particularly if a plugin were to send many `createCases`/`createItems` requests in quick succession, so perhaps the updates should be throttled in some way. Or perhaps the multidata plugin can respond more efficiently to added cases/items than simply calling `refreshDataSetInfo()`. 🤷‍♂️