### PR TITLE
fix: drag/drop collision detection

### DIFF
--- a/src/components/nested-table-view/common/draggable-table-tags.tsx
+++ b/src/components/nested-table-view/common/draggable-table-tags.tsx
@@ -56,7 +56,7 @@ interface DraggableTableHeaderProps {
 }
 
 export const DraggableTableHeader: React.FC<PropsWithChildren<DraggableTableHeaderProps>> =
-  observer(function DraggagleTableHeader(props) {
+  observer(function DraggableTableHeader(props) {
     const {collectionId, attrTitle, caseId, dataSetName, editableHasFocus, children,
        isParent, attrId, renameAttribute, colSpan} = props;
 

--- a/src/components/nested-table-view/nested-table.tsx
+++ b/src/components/nested-table-view/nested-table.tsx
@@ -4,8 +4,9 @@ import { observer } from "mobx-react-lite";
 import { IResult } from "@concord-consortium/codap-plugin-api";
 import { InteractiveState } from "../../hooks/useCodapState";
 import { DraggableTableContext, useDraggableTable } from "../../hooks/useDraggableTable";
-import { ICollection, IProcessedCaseObj, Values, ICollectionClass, IDataSet } from "../../types";
 import { CollectionsModelType } from "../../models/collections";
+import { ICollection, IProcessedCaseObj, Values, ICollectionClass, IDataSet } from "../../types";
+import { nestedTableCollisionDetection } from "../../utils/table-collision-detection";
 import { Menu } from "../menu";
 import { FlatTable } from "./flat/flat-table";
 import { LandscapeTable } from "./landscape/landscape-table";
@@ -150,7 +151,8 @@ export const NestedTable = observer(function NestedTable(props: IProps) {
         defaultDisplayMode="Portrait"
       />
       <DraggableTableContext.Provider value={draggableTable}>
-        <DndContext onDragEnd={draggableTable.handleDrop} sensors={sensors}>
+        <DndContext collisionDetection={nestedTableCollisionDetection} sensors={sensors}
+          onDragEnd={draggableTable.handleDrop}>
           {selectedDataSet && renderTable()}
         </DndContext>
       </DraggableTableContext.Provider>

--- a/src/utils/table-collision-detection.ts
+++ b/src/utils/table-collision-detection.ts
@@ -1,0 +1,41 @@
+import { CollisionDescriptor, CollisionDetection, pointerWithin } from "@dnd-kit/core";
+
+export const nestedTableCollisionDetection: CollisionDetection = (args) => {
+  // First, let's see if there are any collisions with the pointer
+  const pointerCollisions = pointerWithin(args);
+  if (pointerCollisions.length > 0) {
+    return pointerCollisions;
+  }
+
+  // If there are no collisions with the pointer, return the droppable that
+  // is closest to the pointer position horizontally.
+  return closestHorizontalCenter(args);
+};
+
+/**
+ * Returns the closest horizontal center to the pointer position or collision rectangle.
+ */
+export const closestHorizontalCenter: CollisionDetection = ({
+  collisionRect,
+  droppableRects,
+  droppableContainers,
+  pointerCoordinates
+}) => {
+  // use pointer coordinates if available; collisionRect seems off in some cases
+  const dragX = pointerCoordinates?.x ?? collisionRect.left + collisionRect.width / 2;
+  const collisions: CollisionDescriptor[] = [];
+
+  for (const droppableContainer of droppableContainers) {
+    const {id} = droppableContainer;
+    const rect = droppableRects.get(id);
+
+    if (rect) {
+      const droppableX = rect.left + rect.width / 2;
+      const distBetween = Math.abs(dragX - droppableX);
+
+      collisions.push({id, data: {droppableContainer, value: distBetween}});
+    }
+  }
+
+  return collisions.sort((a, b) => a.data.value - b.data.value);
+};


### PR DESCRIPTION
[[MULTI-2](https://concord-consortium.atlassian.net/browse/MULTI-2)]

We replace the DnD kit default of rectangle intersection with a custom collision detection algorithm that considers first whether the pointer is within a droppable area followed by the closest droppable area horizontally.

Testable at [Test Multidata drag/drop collision detection](https://codap3.concord.org?sample=mammals&di=https://models-resources.concord.org/multidata-plugin/branch/multi-2-collection-detection/index.html).

[MULTI-2]: https://concord-consortium.atlassian.net/browse/MULTI-2?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ