### PR TITLE
Sync selection between plugin and CODAP 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "tslib": "^2.4.0"
       },
       "devDependencies": {
-        "@concord-consortium/codap-plugin-api": "^0.1.8",
+        "@concord-consortium/codap-plugin-api": "^0.1.9",
         "@cypress/code-coverage": "^3.12.45",
         "@cypress/webpack-preprocessor": "^6.0.2",
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
@@ -3309,11 +3309,10 @@
       }
     },
     "node_modules/@concord-consortium/codap-plugin-api": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/codap-plugin-api/-/codap-plugin-api-0.1.8.tgz",
-      "integrity": "sha512-YAC9WaweQtP/chyZNpOjaBOdGdVMgNOgswNJYAv6TWq74goXRocg7A0sgX5UdOuoCmxpx3i14SLyXqV18w1YZw==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/codap-plugin-api/-/codap-plugin-api-0.1.9.tgz",
+      "integrity": "sha512-/f8lvkkYxXRpDY9T1T8u1UPKHJ2py3Yziqf5Ku4q1tPQ1Nk7H2UyuxHjKtMTqaj9qv10PQi4bno/P0NnwoMqSQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "fork-ts-checker-webpack-plugin": "^9.0.2",
         "iframe-phone": "^1.3.1"

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "report-dir": "coverage-cypress"
   },
   "devDependencies": {
-    "@concord-consortium/codap-plugin-api": "^0.1.8",
+    "@concord-consortium/codap-plugin-api": "^0.1.9",
     "@cypress/code-coverage": "^3.12.45",
     "@cypress/webpack-preprocessor": "^6.0.2",
     "@istanbuljs/nyc-config-typescript": "^1.0.2",

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -12,7 +12,7 @@ function App() {
          updateInteractiveState: _updateInteractiveState, init,
          handleSelectDataSet: _handleSelectDataSet, handleUpdateAttributePosition,
          handleAddCollection, handleAddAttribute, handleSelectSelf,
-         updateTitle, selectCODAPCases, listenForSelectionChanges,
+         updateTitle, selectCODAPCases, getSelectionList, listenForSelectionChanges,
          handleCreateCollectionFromAttribute, handleSetCollections,
          editCaseValue, renameAttribute } = useCodapState();
   const collections = collectionsModel.collections;
@@ -75,20 +75,20 @@ function App() {
   }, [interactiveState, dataSets, selectedDataSet, _handleSelectDataSet]);
 
   const listeningToDataSetId = useRef(0);
-  const [codapSelectedCase, setCodapSelectedCase] = useState<ICaseObjCommon|undefined>(undefined);
+  const [codapSelectedCases, setCodapSelectedCases] = useState<ICaseObjCommon[]|undefined>(undefined);
   useEffect(() => {
     if (selectedDataSet && listeningToDataSetId.current !== selectedDataSet.id) {
-      listenForSelectionChanges((notification) => {
+      listenForSelectionChanges(async (notification) => {
         const result = notification?.values?.result;
-        let newCase: ICaseObjCommon|undefined = undefined;
+        let newCases: ICaseObjCommon[]|undefined = undefined;
         if (result?.success && result.cases?.length >= 0) {
-          newCase = result.cases[0];
+          newCases = result.cases;
         }
-        setCodapSelectedCase(newCase);
+        setCodapSelectedCases(newCases);
       });
       listeningToDataSetId.current = selectedDataSet.id;
     }
-  }, [selectedDataSet, listenForSelectionChanges, setCodapSelectedCase]);
+  }, [selectedDataSet, listenForSelectionChanges, getSelectionList, ]);
 
   if (!connected) {
     return <div className={css.loading}>Loading...</div>;
@@ -111,7 +111,8 @@ function App() {
           editCaseValue={editCaseValue}
           handleAddAttribute={handleAddAttribute}
           renameAttribute={renameAttribute}
-          codapSelectedCases={codapSelectedCase}
+          selectCases={selectCODAPCases}
+          codapSelectedCases={codapSelectedCases}
         />
       );
 
@@ -142,7 +143,7 @@ function App() {
           handleSelectDataSet={handleSelectDataSet}
           updateTitle={updateTitle}
           selectCases={selectCODAPCases}
-          codapSelectedCase={codapSelectedCase}
+          codapSelectedCase={codapSelectedCases?.[0]}
         />
       );
 

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -35,8 +35,7 @@ function App() {
     updateInteractiveState({view});
   }, [updateInteractiveState]);
 
-  const handleSelectDataSet = useCallback(
-      async (e: React.ChangeEvent<HTMLSelectElement>, defaultDisplayMode?: string) => {
+  const handleSelectDataSet = useCallback((e: React.ChangeEvent<HTMLSelectElement>, defaultDisplayMode?: string) => {
     const dataSetName = e.target.value;
     _handleSelectDataSet(dataSetName);
     const update: Partial<InteractiveState> = {dataSetName};
@@ -72,13 +71,13 @@ function App() {
 
   //if there is a selected dataset, check if there are selected cases
   useEffect(() => {
-    const fetchData = async () => {
+    const fetchSelectedCases = async () => {
       if (selectedDataSet  && !selectionList) {
         const initSelectedCases: ISelectedCase[] = await updateSelection();
         setSelectionList(initSelectedCases);
       }
     };
-    fetchData();
+    fetchSelectedCases();
   }, [selectedDataSet, selectionList, updateSelection]);
   // unselect the dataset if it is deleted
   useEffect(() => {

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -65,16 +65,16 @@ function App() {
 
   // select the saved dataset on startup
   useEffect(() => {
-      if (interactiveState?.dataSetName && !selectedDataSet) {
-        _handleSelectDataSet(interactiveState.dataSetName);
-      }
+    if (interactiveState?.dataSetName && !selectedDataSet) {
+      _handleSelectDataSet(interactiveState.dataSetName);
+    }
   }, [interactiveState, selectedDataSet, _handleSelectDataSet]);
 
   //if there is a selected dataset, check if there are selected cases
   useEffect(() => {
     const fetchData = async () => {
       if (selectedDataSet  && !selectionList) {
-        const initSelectedCases: ISelectedCase[] = await updateSelection()
+        const initSelectedCases: ISelectedCase[] = await updateSelection();
         setSelectionList(initSelectedCases);
       }
     };

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -111,6 +111,7 @@ function App() {
           editCaseValue={editCaseValue}
           handleAddAttribute={handleAddAttribute}
           renameAttribute={renameAttribute}
+          codapSelectedCases={codapSelectedCase}
         />
       );
 

--- a/src/components/card-view/card-view.tsx
+++ b/src/components/card-view/card-view.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo } from "react";
 import { observer } from "mobx-react-lite";
 import { InteractiveState } from "../../hooks/useCodapState";
-import { IDataSet, ICaseObjCommon, ICollection } from "../../types";
+import { IDataSet, ICaseObjCommon, ICollection, ISelectedCase } from "../../types";
 import { Menu } from "../menu";
 import { CaseView } from "./case-view";
 import { CollectionsModelType } from "../../models/collections";
@@ -16,16 +16,17 @@ interface ICardViewProps {
   handleSelectDataSet: (e: React.ChangeEvent<HTMLSelectElement>) => void
   updateTitle: (title: string) => Promise<void>
   selectCases: (caseIds: number[]) => Promise<void>
-  codapSelectedCase: ICaseObjCommon|undefined;
+  selectedCase: ISelectedCase | undefined;
 }
 
 export const CardView = observer(function CardView(props: ICardViewProps) {
-  const {collectionsModel, dataSets, selectedDataSet, updateTitle, selectCases, codapSelectedCase,
-         handleSelectDataSet} = props;
+  const {collectionsModel, dataSets, selectedDataSet, updateTitle, selectCases,
+         handleSelectDataSet, selectedCase} = props;
 
   const collections = collectionsModel.collections;
   const rootCollection = collectionsModel.rootCollection;
   const attrs = collectionsModel.attrs;
+  const selectedCaseCollection = collectionsModel.collections.find(c => c.id === selectedCase?.collectionID);
 
   useEffect(() => {
     if (selectedDataSet?.title) {
@@ -35,7 +36,7 @@ export const CardView = observer(function CardView(props: ICardViewProps) {
 
   // array of case ids from root collection down to selected case
   const codapSelectedCaseLineage = useMemo<number[]>(() => {
-    if (!codapSelectedCase) {
+    if (!selectedCase) {
       return [];
     }
 
@@ -45,7 +46,7 @@ export const CardView = observer(function CardView(props: ICardViewProps) {
     }, {});
 
     const result: number[] = [];
-    let caseItem: ICaseObjCommon|undefined = codapSelectedCase;
+    let caseItem: ICaseObjCommon|undefined = selectedCaseCollection?.cases.find(c => c.id === selectedCase.caseID);
     while (caseItem) {
       const {id, parent} = caseItem;
       result.unshift(id);
@@ -56,7 +57,7 @@ export const CardView = observer(function CardView(props: ICardViewProps) {
     }
 
     return result;
-  }, [codapSelectedCase, collections]);
+  }, [collections, selectedCase, selectedCaseCollection?.cases]);
 
   if (!selectedDataSet || !rootCollection) {
     return (

--- a/src/components/nested-table-view/common/draggable-table-tags.tsx
+++ b/src/components/nested-table-view/common/draggable-table-tags.tsx
@@ -10,7 +10,7 @@ import {
 } from "../../../utils/apiHelpers";
 import { getDisplayValue } from "../../../utils/utils";
 import {
-  ICollection, ICollections, IDndData, IProcessedCaseObj, isCollectionData, PropsWithChildren
+  ICollection, ICollections, IDndData, IProcessedCaseObj, isCollectionData, ISelectedCase, PropsWithChildren
 } from "../../../types";
 import { EditableTableCell } from "./editable-table-cell";
 import { AddAttributeButton } from "./add-attribute-button";
@@ -283,13 +283,14 @@ interface DraggableTableDataProps {
   precisions: Record<string, number>;
   attrTypes: Record<string, string | undefined | null>;
   editCaseValue: (newValue: string, caseObj: IProcessedCaseObj, attrTitle: string) => Promise<IResult | undefined>;
-  onSelectCase?: (caseId: number, e: React.MouseEvent<HTMLDivElement>) => void;
+  onSelectCase?: (caseId: number | number[], e: React.MouseEvent<HTMLDivElement>) => void;
+  selectionList?: ISelectedCase[];
 }
 
 export const DraggableTableData: React.FC<PropsWithChildren<DraggableTableDataProps>> =
   observer(function DraggableTableData(props) {
     const {collectionId, attrTitle, attrTypes, caseObj, isParent, parentLevel=0, precisions, editCaseValue,
-            onSelectCase} = props;
+            onSelectCase, selectionList} = props;
     const { dragSide } = useDraggableTableContext();
     const { over } = useDndContext();
     const style = getStyle(collectionId, attrTitle, over, dragSide);
@@ -357,6 +358,7 @@ export const DraggableTableData: React.FC<PropsWithChildren<DraggableTableDataPr
                   precisions={precisions}
                   attrTypes={attrTypes}
                   onSelectCase={onSelectCase}
+                  selectionList={selectionList}
                 />
               </div>
             </>
@@ -366,6 +368,8 @@ export const DraggableTableData: React.FC<PropsWithChildren<DraggableTableDataPr
               editCaseValue={editCaseValue}
               precisions={precisions}
               attrTypes={attrTypes}
+              onSelectCase={onSelectCase}
+              selectionList={selectionList}
             />
         }
       </td>

--- a/src/components/nested-table-view/common/draggable-table-tags.tsx
+++ b/src/components/nested-table-view/common/draggable-table-tags.tsx
@@ -283,11 +283,13 @@ interface DraggableTableDataProps {
   precisions: Record<string, number>;
   attrTypes: Record<string, string | undefined | null>;
   editCaseValue: (newValue: string, caseObj: IProcessedCaseObj, attrTitle: string) => Promise<IResult | undefined>;
+  onSelectCase?: (caseId: number, e: React.MouseEvent<HTMLDivElement>) => void;
 }
 
 export const DraggableTableData: React.FC<PropsWithChildren<DraggableTableDataProps>> =
   observer(function DraggableTableData(props) {
-    const {collectionId, attrTitle, attrTypes, caseObj, isParent, parentLevel=0, precisions, editCaseValue} = props;
+    const {collectionId, attrTitle, attrTypes, caseObj, isParent, parentLevel=0, precisions, editCaseValue,
+            onSelectCase} = props;
     const { dragSide } = useDraggableTableContext();
     const { over } = useDndContext();
     const style = getStyle(collectionId, attrTitle, over, dragSide);
@@ -354,6 +356,7 @@ export const DraggableTableData: React.FC<PropsWithChildren<DraggableTableDataPr
                   editCaseValue={editCaseValue}
                   precisions={precisions}
                   attrTypes={attrTypes}
+                  onSelectCase={onSelectCase}
                 />
               </div>
             </>

--- a/src/components/nested-table-view/common/editable-table-cell.scss
+++ b/src/components/nested-table-view/common/editable-table-cell.scss
@@ -16,9 +16,16 @@
       width: 100%;
     }
   }
+}
 
-  input {
-    background: white;
-    width: calc(100% - 8px);
-  }
+.editableInput {
+  background: white;
+  width: calc(100% - 8px);
+  font-size: 8pt;
+  height: 100% !important;
+  text-wrap: wrap;
+  resize: none;
+  font-family: "Montserrat", sans-serif;
+  line-height: normal;
+  margin: 10px 0;
 }

--- a/src/components/nested-table-view/common/editable-table-cell.tsx
+++ b/src/components/nested-table-view/common/editable-table-cell.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { observer } from "mobx-react-lite";
-import { Editable, EditablePreview, EditableInput, Input } from "@chakra-ui/react";
+import { Editable, EditablePreview, EditableInput, Input, Box, Text, Textarea } from "@chakra-ui/react";
 import { IResult } from "@concord-consortium/codap-plugin-api";
 import { IProcessedCaseObj } from "../../../types";
 import { getDisplayValue } from "../../../utils/utils";
@@ -23,8 +23,8 @@ export const EditableTableCell = observer(function EditableTableCell(props: IPro
   const [editingValue, setEditingValue] = useState(displayValue);
   const [isEditing, setIsEditing] = useState(false);
 
-  const handleChangeValue = (newValue: string) => {
-    setEditingValue(newValue);
+  const handleChangeValue = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setEditingValue(e.target.value);
   };
 
   const handleCancel = () => {
@@ -57,25 +57,33 @@ export const EditableTableCell = observer(function EditableTableCell(props: IPro
     e.preventDefault();
     setIsEditing(true);
   };
-console.log("isEditing", isEditing);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter") {
+      handleSubmit((e.target as HTMLTextAreaElement).value);
+    }
+    if (e.key === "Escape") {
+      handleCancel();
+    }
+  };
+
   return (
     <div className={css.editableTableCell}>
-      <Editable
-        isPreviewFocusable={true}
-        onCancel={handleCancel}
-        onChange={handleChangeValue}
-        onEdit={() => setIsEditing(true)}
-        onDoubleClick={handleStartEdit}
-        onSubmit={handleSubmit}
-        submitOnBlur={true}
-        value={isEditing ? editingValue : displayValue}
-        onClick={(e)=>handleCellClick(e)}
-      >
-        {!isEditing && <EditablePreview
-                  onClick={(e) => handleCellClick(e)}
-                  onDoubleClick={(e) => handleStartEdit(e)}/>}
-        <EditableInput />
-      </Editable>
+      <Box onClick={handleCellClick} position="relative" height="100%" width="100%">
+        {isEditing
+          ? <Textarea
+              className={css.editableInput}
+              value={editingValue}
+              onChange={(e) => handleChangeValue(e)}
+              onBlur={(e) => handleSubmit(e.target.value)}
+              onKeyDown={handleKeyDown}
+              autoFocus
+            />
+        : <Text onDoubleClick={handleStartEdit} cursor="pointer">
+            {displayValue}
+          </Text>
+        }
+      </Box>
     </div>
   );
 });

--- a/src/components/nested-table-view/common/editable-table-cell.tsx
+++ b/src/components/nested-table-view/common/editable-table-cell.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react";
 import { observer } from "mobx-react-lite";
-import { Editable, EditablePreview, EditableInput, Input, Box, Text, Textarea } from "@chakra-ui/react";
+import { Box, Text, Textarea } from "@chakra-ui/react";
 import { IResult } from "@concord-consortium/codap-plugin-api";
-import { IProcessedCaseObj } from "../../../types";
+import { IProcessedCaseObj, ISelectedCase } from "../../../types";
 import { getDisplayValue } from "../../../utils/utils";
 
 import css from "./editable-table-cell.scss";
@@ -13,11 +13,12 @@ interface IProps {
   editCaseValue: (newValue: string, cCase: IProcessedCaseObj, attrTitle: string) => Promise<IResult | undefined>;
   precisions: Record<string, number>;
   attrTypes: Record<string, string | undefined | null>;
-  onSelectCase?: (caseId: number, e: React.MouseEvent<HTMLDivElement>) => void;
+  onSelectCase?: (caseId: number | number[], e: React.MouseEvent<HTMLDivElement>) => void;
+  selectionList?: ISelectedCase[];
 }
 
 export const EditableTableCell = observer(function EditableTableCell(props: IProps) {
-  const { attrTitle, case: cCase, editCaseValue, attrTypes, precisions, onSelectCase } = props;
+  const { attrTitle, case: cCase, editCaseValue, attrTypes, precisions, onSelectCase, selectionList } = props;
   const cellValue = cCase.values.get(attrTitle);
   const displayValue = getDisplayValue(cellValue, attrTitle, attrTypes, precisions);
   const [editingValue, setEditingValue] = useState(displayValue);
@@ -49,7 +50,12 @@ export const EditableTableCell = observer(function EditableTableCell(props: IPro
   const handleCellClick = (e: React.MouseEvent<HTMLDivElement>) => {
     e.preventDefault();
     if (isEditing) return;
-    onSelectCase?.(cCase.id, e);
+    const isExtending = e.altKey || e.metaKey;
+    const selectedCasesIdsArray = selectionList?.map(sCase => sCase.caseID);
+    const selectCasesArray = isExtending && selectedCasesIdsArray
+            ? [...selectedCasesIdsArray, cCase.id]
+            : [cCase.id];
+    selectCasesArray && onSelectCase?.(selectCasesArray, e);
     setIsEditing(false);
   };
 

--- a/src/components/nested-table-view/common/editable-table-cell.tsx
+++ b/src/components/nested-table-view/common/editable-table-cell.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { observer } from "mobx-react-lite";
-import { Editable, EditablePreview, EditableInput } from "@chakra-ui/react";
+import { Editable, EditablePreview, EditableInput, Input } from "@chakra-ui/react";
 import { IResult } from "@concord-consortium/codap-plugin-api";
 import { IProcessedCaseObj } from "../../../types";
 import { getDisplayValue } from "../../../utils/utils";
@@ -13,10 +13,11 @@ interface IProps {
   editCaseValue: (newValue: string, cCase: IProcessedCaseObj, attrTitle: string) => Promise<IResult | undefined>;
   precisions: Record<string, number>;
   attrTypes: Record<string, string | undefined | null>;
+  onSelectCase?: (caseId: number, e: React.MouseEvent<HTMLDivElement>) => void;
 }
 
 export const EditableTableCell = observer(function EditableTableCell(props: IProps) {
-  const { attrTitle, case: cCase, editCaseValue, attrTypes, precisions } = props;
+  const { attrTitle, case: cCase, editCaseValue, attrTypes, precisions, onSelectCase } = props;
   const cellValue = cCase.values.get(attrTitle);
   const displayValue = getDisplayValue(cellValue, attrTitle, attrTypes, precisions);
   const [editingValue, setEditingValue] = useState(displayValue);
@@ -45,6 +46,18 @@ export const EditableTableCell = observer(function EditableTableCell(props: IPro
     }
   };
 
+  const handleCellClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    if (isEditing) return;
+    onSelectCase?.(cCase.id, e);
+    setIsEditing(false);
+  };
+
+  const handleStartEdit = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsEditing(true);
+  };
+console.log("isEditing", isEditing);
   return (
     <div className={css.editableTableCell}>
       <Editable
@@ -52,11 +65,15 @@ export const EditableTableCell = observer(function EditableTableCell(props: IPro
         onCancel={handleCancel}
         onChange={handleChangeValue}
         onEdit={() => setIsEditing(true)}
+        onDoubleClick={handleStartEdit}
         onSubmit={handleSubmit}
         submitOnBlur={true}
         value={isEditing ? editingValue : displayValue}
+        onClick={(e)=>handleCellClick(e)}
       >
-        {!isEditing && <EditablePreview />}
+        {!isEditing && <EditablePreview
+                  onClick={(e) => handleCellClick(e)}
+                  onDoubleClick={(e) => handleStartEdit(e)}/>}
         <EditableInput />
       </Editable>
     </div>

--- a/src/components/nested-table-view/common/table-cells.tsx
+++ b/src/components/nested-table-view/common/table-cells.tsx
@@ -14,11 +14,12 @@ interface IProps {
   parentLevel?: number;
   selectedDataSetName: string;
   editCaseValue: (newValue: string, caseObj: IProcessedCaseObj, attrTitle: string) => Promise<IResult | undefined>;
+  onSelectCase?: (caseId: number, e: React.MouseEvent<HTMLDivElement>) => void;
 }
 
 export const TableCells = (props: IProps) => {
   const { collectionId, rowKey, cCase, precisions, attrTypes, attrVisibilities, isParent, parentLevel,
-    selectedDataSetName, editCaseValue } = props;
+    selectedDataSetName, editCaseValue, onSelectCase } = props;
   if (!selectedDataSetName) return null;
   const aCase = cCase.values;
   return (
@@ -42,6 +43,7 @@ export const TableCells = (props: IProps) => {
             parentLevel={parentLevel}
             selectedDataSetName={selectedDataSetName}
             editCaseValue={editCaseValue}
+            onSelectCase={onSelectCase}
           />
         );
       })}

--- a/src/components/nested-table-view/common/table-cells.tsx
+++ b/src/components/nested-table-view/common/table-cells.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { IProcessedCaseObj } from "../../../types";
+import { IProcessedCaseObj, ISelectedCase } from "../../../types";
 import { DraggableTableData } from "./draggable-table-tags";
 import { IResult } from "@concord-consortium/codap-plugin-api";
 
@@ -14,12 +14,13 @@ interface IProps {
   parentLevel?: number;
   selectedDataSetName: string;
   editCaseValue: (newValue: string, caseObj: IProcessedCaseObj, attrTitle: string) => Promise<IResult | undefined>;
-  onSelectCase?: (caseId: number, e: React.MouseEvent<HTMLDivElement>) => void;
+  onSelectCase?: (caseId: number | number[], e: React.MouseEvent<HTMLDivElement>) => void;
+  selectionList?: ISelectedCase[];
 }
 
 export const TableCells = (props: IProps) => {
   const { collectionId, rowKey, cCase, precisions, attrTypes, attrVisibilities, isParent, parentLevel,
-    selectedDataSetName, editCaseValue, onSelectCase } = props;
+    selectedDataSetName, editCaseValue, onSelectCase, selectionList } = props;
   if (!selectedDataSetName) return null;
   const aCase = cCase.values;
   return (
@@ -44,6 +45,7 @@ export const TableCells = (props: IProps) => {
             selectedDataSetName={selectedDataSetName}
             editCaseValue={editCaseValue}
             onSelectCase={onSelectCase}
+            selectionList={selectionList}
           />
         );
       })}

--- a/src/components/nested-table-view/common/tables.scss
+++ b/src/components/nested-table-view/common/tables.scss
@@ -277,6 +277,10 @@ table.draggableTableContainer {
   box-sizing: border-box;
 }
 
+.selected {
+  background-color: #EEFEE3;
+}
+
 .draggable-table-data {
   box-sizing: border-box;
 }

--- a/src/components/nested-table-view/nested-table.tsx
+++ b/src/components/nested-table-view/nested-table.tsx
@@ -5,7 +5,7 @@ import { IResult } from "@concord-consortium/codap-plugin-api";
 import { InteractiveState } from "../../hooks/useCodapState";
 import { DraggableTableContext, useDraggableTable } from "../../hooks/useDraggableTable";
 import { CollectionsModelType } from "../../models/collections";
-import { ICollection, IProcessedCaseObj, Values, ICollectionClass, IDataSet } from "../../types";
+import { ICollection, IProcessedCaseObj, Values, ICollectionClass, IDataSet, ICaseObjCommon } from "../../types";
 import { nestedTableCollisionDetection } from "../../utils/table-collision-detection";
 import { Menu } from "../menu";
 import { FlatTable } from "./flat/flat-table";
@@ -32,13 +32,14 @@ interface IProps {
   editCaseValue: (newValue: string, caseObj: IProcessedCaseObj, attrTitle: string) => Promise<IResult | undefined>;
   handleAddAttribute: (collection: ICollection, attrName: string, tableIndex: number) => Promise<void>;
   renameAttribute: (collectionName: string, attrId: number, oldName: string, newName: string) => Promise<void>;
+  codapSelectedCases: ICaseObjCommon | undefined;
 }
 
 export const NestedTable = observer(function NestedTable(props: IProps) {
   const {selectedDataSet, dataSets, collectionsModel, cases, interactiveState,
          handleSelectDataSet, updateInteractiveState, handleShowComponent,
          handleUpdateAttributePosition, handleCreateCollectionFromAttribute,
-         editCaseValue, renameAttribute, handleAddAttribute} = props;
+         editCaseValue, renameAttribute, handleAddAttribute, codapSelectedCases} = props;
   const [collectionClasses, setCollectionClasses] = useState<ICollectionClass[]>([]);
   const [paddingStyle, setPaddingStyle] = useState<Record<string, string>>({padding: "0px"});
   const collections = collectionsModel.collections;
@@ -112,7 +113,8 @@ export const NestedTable = observer(function NestedTable(props: IProps) {
     const tableProps = {showHeaders: interactiveState.showHeaders, collectionClasses, collectionsModel,
       selectedDataSet, getClassName, getValueLength, paddingStyle, editCaseValue,
       dataSetName: selectedDataSet.name, renameAttribute, handleAddAttribute,
-      activeTableIndex: interactiveState.activeTableIndex};
+      activeTableIndex: interactiveState.activeTableIndex, codapSelectedCases
+    };
     const flatProps = {...tableProps, cases};
     if (isNoHierarchy && classesExist) {
       return <FlatTable {...flatProps}/>;

--- a/src/components/nested-table-view/nested-table.tsx
+++ b/src/components/nested-table-view/nested-table.tsx
@@ -32,14 +32,15 @@ interface IProps {
   editCaseValue: (newValue: string, caseObj: IProcessedCaseObj, attrTitle: string) => Promise<IResult | undefined>;
   handleAddAttribute: (collection: ICollection, attrName: string, tableIndex: number) => Promise<void>;
   renameAttribute: (collectionName: string, attrId: number, oldName: string, newName: string) => Promise<void>;
-  codapSelectedCases: ICaseObjCommon | undefined;
+  selectCases?: (caseIds: number[]) => Promise<void>;
+  codapSelectedCases: ICaseObjCommon[] | undefined;
 }
 
 export const NestedTable = observer(function NestedTable(props: IProps) {
   const {selectedDataSet, dataSets, collectionsModel, cases, interactiveState,
          handleSelectDataSet, updateInteractiveState, handleShowComponent,
          handleUpdateAttributePosition, handleCreateCollectionFromAttribute,
-         editCaseValue, renameAttribute, handleAddAttribute, codapSelectedCases} = props;
+         editCaseValue, renameAttribute, handleAddAttribute, selectCases, codapSelectedCases} = props;
   const [collectionClasses, setCollectionClasses] = useState<ICollectionClass[]>([]);
   const [paddingStyle, setPaddingStyle] = useState<Record<string, string>>({padding: "0px"});
   const collections = collectionsModel.collections;
@@ -113,7 +114,7 @@ export const NestedTable = observer(function NestedTable(props: IProps) {
     const tableProps = {showHeaders: interactiveState.showHeaders, collectionClasses, collectionsModel,
       selectedDataSet, getClassName, getValueLength, paddingStyle, editCaseValue,
       dataSetName: selectedDataSet.name, renameAttribute, handleAddAttribute,
-      activeTableIndex: interactiveState.activeTableIndex, codapSelectedCases
+      activeTableIndex: interactiveState.activeTableIndex, selectCases, codapSelectedCases
     };
     const flatProps = {...tableProps, cases};
     if (isNoHierarchy && classesExist) {

--- a/src/components/nested-table-view/nested-table.tsx
+++ b/src/components/nested-table-view/nested-table.tsx
@@ -5,7 +5,7 @@ import { IResult } from "@concord-consortium/codap-plugin-api";
 import { InteractiveState } from "../../hooks/useCodapState";
 import { DraggableTableContext, useDraggableTable } from "../../hooks/useDraggableTable";
 import { CollectionsModelType } from "../../models/collections";
-import { ICollection, IProcessedCaseObj, Values, ICollectionClass, IDataSet, ICaseObjCommon } from "../../types";
+import { ICollection, IProcessedCaseObj, Values, ICollectionClass, IDataSet, ISelectedCase } from "../../types";
 import { nestedTableCollisionDetection } from "../../utils/table-collision-detection";
 import { Menu } from "../menu";
 import { FlatTable } from "./flat/flat-table";
@@ -33,14 +33,15 @@ interface IProps {
   handleAddAttribute: (collection: ICollection, attrName: string, tableIndex: number) => Promise<void>;
   renameAttribute: (collectionName: string, attrId: number, oldName: string, newName: string) => Promise<void>;
   selectCases?: (caseIds: number[]) => Promise<void>;
-  codapSelectedCases: ICaseObjCommon[] | undefined;
+  selectionList?: ISelectedCase[];
 }
 
 export const NestedTable = observer(function NestedTable(props: IProps) {
   const {selectedDataSet, dataSets, collectionsModel, cases, interactiveState,
          handleSelectDataSet, updateInteractiveState, handleShowComponent,
          handleUpdateAttributePosition, handleCreateCollectionFromAttribute,
-         editCaseValue, renameAttribute, handleAddAttribute, selectCases, codapSelectedCases} = props;
+         editCaseValue, renameAttribute, handleAddAttribute, selectCases,
+         selectionList} = props;
   const [collectionClasses, setCollectionClasses] = useState<ICollectionClass[]>([]);
   const [paddingStyle, setPaddingStyle] = useState<Record<string, string>>({padding: "0px"});
   const collections = collectionsModel.collections;
@@ -114,7 +115,7 @@ export const NestedTable = observer(function NestedTable(props: IProps) {
     const tableProps = {showHeaders: interactiveState.showHeaders, collectionClasses, collectionsModel,
       selectedDataSet, getClassName, getValueLength, paddingStyle, editCaseValue,
       dataSetName: selectedDataSet.name, renameAttribute, handleAddAttribute,
-      activeTableIndex: interactiveState.activeTableIndex, selectCases, codapSelectedCases
+      activeTableIndex: interactiveState.activeTableIndex, selectCases, selectionList
     };
     const flatProps = {...tableProps, cases};
     if (isNoHierarchy && classesExist) {

--- a/src/components/nested-table-view/portrait/portrait-table-row.tsx
+++ b/src/components/nested-table-view/portrait/portrait-table-row.tsx
@@ -7,6 +7,9 @@ import { DraggableTableContainer, DroppableTableData, DroppableTableHeader } fro
 
 import css from "../common/tables.scss";
 
+const kTableHeaderHeight = 60;
+const kParentLevelHeight = 20;
+
 export type PortraitTableRowProps = {
   caseObj: IProcessedCaseObj, index?: null | number,
   isParent: boolean, parentLevel?: number
@@ -25,7 +28,8 @@ export const PortraitTableRow = observer(function PortraitTableRow(props: Portra
 
   useEffect(() => {
     if (selectedCase && rowRef.current) {
-      const offset = 60 + (20 * parentLevel); // Offset for the table header and each parent level
+      // Offset for the table header and each parent level
+      const offset = kTableHeaderHeight + (kParentLevelHeight * parentLevel);
       const top = rowRef.current.getBoundingClientRect().top + window.scrollY - offset;
       window.scrollTo({ top, behavior: "smooth" });    }
   }, [parentLevel, selectedCase]);

--- a/src/components/nested-table-view/portrait/portrait-table-row.tsx
+++ b/src/components/nested-table-view/portrait/portrait-table-row.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef } from "react";
 import { IProcessedCaseObj, ITableProps } from "../../../types";
 import { observer } from "mobx-react-lite";
 import { TableCells } from "../common/table-cells";

--- a/src/components/nested-table-view/portrait/portrait-table-row.tsx
+++ b/src/components/nested-table-view/portrait/portrait-table-row.tsx
@@ -16,11 +16,11 @@ export type PortraitTableRowProps = {
 export const PortraitTableRow = observer(function PortraitTableRow(props: PortraitTableRowProps) {
   const { paddingStyle, showHeaders, getClassName, caseObj, index, isParent, parentLevel = 0, dataSetName,
     handleAddAttribute, collectionsModel, renameAttribute, editCaseValue,
-    selectedDataSet, getsFocusOnAddAttr, tableIndex, selectCases, codapSelectedCases } = props;
+    selectedDataSet, getsFocusOnAddAttr, tableIndex, selectCases, selectionList } = props;
   const { collections, attrVisibilities, attrPrecisions, attrTypes } = collectionsModel;
   const collectionId = caseObj.collection.id;
   const { children, id, values } = caseObj;
-  const selectedCase = codapSelectedCases?.some(sCase => sCase.id === id);
+  const selectedCase = selectionList?.some(sCase => sCase.caseID === id);
   const rowRef = useRef<HTMLTableRowElement>(null);
 
   useEffect(() => {
@@ -30,9 +30,9 @@ export const PortraitTableRow = observer(function PortraitTableRow(props: Portra
       window.scrollTo({ top, behavior: "smooth" });    }
   }, [parentLevel, selectedCase]);
 
-  const handleSelectCase = (caseId: number, e: React.MouseEvent<HTMLDivElement>) => {
+  const handleSelectCase = (caseIds: number | number[], e: React.MouseEvent<HTMLDivElement>) => {
     e.stopPropagation();
-    selectCases?.([caseId]);
+    selectCases?.(Array.isArray(caseIds) ? caseIds : [caseIds]);
   };
 
   if (!children.length) {
@@ -51,6 +51,7 @@ export const PortraitTableRow = observer(function PortraitTableRow(props: Portra
           selectedDataSetName={dataSetName}
           editCaseValue={editCaseValue}
           onSelectCase={handleSelectCase}
+          selectionList={selectionList}
         />
       </tr>
     );
@@ -98,6 +99,7 @@ export const PortraitTableRow = observer(function PortraitTableRow(props: Portra
             parentLevel={parentLevel}
             selectedDataSetName={dataSetName}
             editCaseValue={editCaseValue}
+            selectionList={selectionList}
           />
           <DroppableTableData collectionId={collectionId} style={paddingStyle}>
             <DraggableTableContainer caseId={id} collectionId={collectionId}>

--- a/src/components/nested-table-view/portrait/portrait-table-row.tsx
+++ b/src/components/nested-table-view/portrait/portrait-table-row.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { IProcessedCaseObj, ITableProps } from "../../../types";
 import { observer } from "mobx-react-lite";
 import { TableCells } from "../common/table-cells";
@@ -16,11 +16,11 @@ export type PortraitTableRowProps = {
 export const PortraitTableRow = observer(function PortraitTableRow(props: PortraitTableRowProps) {
   const { paddingStyle, showHeaders, getClassName, caseObj, index, isParent, parentLevel = 0, dataSetName,
     handleAddAttribute, collectionsModel, renameAttribute, editCaseValue,
-    selectedDataSet, getsFocusOnAddAttr, tableIndex, codapSelectedCases } = props;
+    selectedDataSet, getsFocusOnAddAttr, tableIndex, selectCases, codapSelectedCases } = props;
   const { collections, attrVisibilities, attrPrecisions, attrTypes } = collectionsModel;
   const collectionId = caseObj.collection.id;
   const { children, id, values } = caseObj;
-  const selectedCase = codapSelectedCases?.id === id;
+  const selectedCase = codapSelectedCases?.some(sCase => sCase.id === id);
   const rowRef = useRef<HTMLTableRowElement>(null);
 
   useEffect(() => {
@@ -30,9 +30,15 @@ export const PortraitTableRow = observer(function PortraitTableRow(props: Portra
       window.scrollTo({ top, behavior: "smooth" });    }
   }, [parentLevel, selectedCase]);
 
+  const handleSelectCase = (caseId: number, e: React.MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+    selectCases?.([caseId]);
+  };
+
   if (!children.length) {
     return (
-      <tr ref={rowRef} className={`${css.tableDataRow} ${selectedCase ? css.selected : ""}`}>
+      <tr ref={rowRef} className={`${selectedCase ? css.selected : ""}`}
+          onClick={(e)=>handleSelectCase(caseObj.id, e)}>
         <TableCells
           collectionId={collectionId}
           rowKey={`row-${index}`}
@@ -44,6 +50,7 @@ export const PortraitTableRow = observer(function PortraitTableRow(props: Portra
           parentLevel={parentLevel}
           selectedDataSetName={dataSetName}
           editCaseValue={editCaseValue}
+          onSelectCase={handleSelectCase}
         />
       </tr>
     );
@@ -78,7 +85,8 @@ export const PortraitTableRow = observer(function PortraitTableRow(props: Portra
             ) : <th />}
           </tr>
         }
-        <tr ref={rowRef} className={`${css[getClassName(caseObj)]} parent-row ${selectedCase ? css.selected : ""}`}>
+        <tr ref={rowRef} className={`${css[getClassName(caseObj)]} parent-row ${selectedCase ? css.selected : ""}`}
+            onClick={(e)=>handleSelectCase(caseObj.id, e)}>
           <TableCells
             collectionId={collectionId}
             rowKey={`parent-row-${index}`}

--- a/src/components/nested-table-view/portrait/portrait-table-row.tsx
+++ b/src/components/nested-table-view/portrait/portrait-table-row.tsx
@@ -16,14 +16,15 @@ export type PortraitTableRowProps = {
 export const PortraitTableRow = observer(function PortraitTableRow(props: PortraitTableRowProps) {
   const { paddingStyle, showHeaders, getClassName, caseObj, index, isParent, parentLevel = 0, dataSetName,
     handleAddAttribute, collectionsModel, renameAttribute, editCaseValue,
-    selectedDataSet, getsFocusOnAddAttr, tableIndex } = props;
+    selectedDataSet, getsFocusOnAddAttr, tableIndex, codapSelectedCases } = props;
   const { collections, attrVisibilities, attrPrecisions, attrTypes } = collectionsModel;
   const collectionId = caseObj.collection.id;
   const { children, id, values } = caseObj;
+  const selectedCase = codapSelectedCases?.id === id;
 
   if (!children.length) {
     return (
-      <tr>
+      <tr className={`${css.tableDataRow} ${selectedCase ? css.selected : ""}`}>
         <TableCells
           collectionId={collectionId}
           rowKey={`row-${index}`}
@@ -69,7 +70,7 @@ export const PortraitTableRow = observer(function PortraitTableRow(props: Portra
             ) : <th />}
           </tr>
         }
-        <tr className={`${css[getClassName(caseObj)]} parent-row`}>
+        <tr className={`${css[getClassName(caseObj)]} parent-row ${selectedCase ? css.selected : ""}`}>
           <TableCells
             collectionId={collectionId}
             rowKey={`parent-row-${index}`}

--- a/src/components/nested-table-view/portrait/portrait-table-row.tsx
+++ b/src/components/nested-table-view/portrait/portrait-table-row.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { IProcessedCaseObj, ITableProps } from "../../../types";
 import { observer } from "mobx-react-lite";
 import { TableCells } from "../common/table-cells";
@@ -21,10 +21,18 @@ export const PortraitTableRow = observer(function PortraitTableRow(props: Portra
   const collectionId = caseObj.collection.id;
   const { children, id, values } = caseObj;
   const selectedCase = codapSelectedCases?.id === id;
+  const rowRef = useRef<HTMLTableRowElement>(null);
+
+  useEffect(() => {
+    if (selectedCase && rowRef.current) {
+      const offset = 60 + (20 * parentLevel); // Offset for the table header and each parent level
+      const top = rowRef.current.getBoundingClientRect().top + window.scrollY - offset;
+      window.scrollTo({ top, behavior: "smooth" });    }
+  }, [parentLevel, selectedCase]);
 
   if (!children.length) {
     return (
-      <tr className={`${css.tableDataRow} ${selectedCase ? css.selected : ""}`}>
+      <tr ref={rowRef} className={`${css.tableDataRow} ${selectedCase ? css.selected : ""}`}>
         <TableCells
           collectionId={collectionId}
           rowKey={`row-${index}`}
@@ -70,7 +78,7 @@ export const PortraitTableRow = observer(function PortraitTableRow(props: Portra
             ) : <th />}
           </tr>
         }
-        <tr className={`${css[getClassName(caseObj)]} parent-row ${selectedCase ? css.selected : ""}`}>
+        <tr ref={rowRef} className={`${css[getClassName(caseObj)]} parent-row ${selectedCase ? css.selected : ""}`}>
           <TableCells
             collectionId={collectionId}
             rowKey={`parent-row-${index}`}

--- a/src/components/nested-table-view/portrait/portrait-table.tsx
+++ b/src/components/nested-table-view/portrait/portrait-table.tsx
@@ -10,7 +10,7 @@ import css from "../common/tables.scss";
 
 export const PortraitTable = observer(function PortraitView(props: ITableProps) {
   const {collectionClasses, collectionsModel, selectedDataSet, getValueLength, dataSetName,
-    handleAddAttribute, activeTableIndex} = props;
+    handleAddAttribute, activeTableIndex, selectionList} = props;
   const { collections } = collectionsModel;
   const tableRef = useRef<HTMLTableElement | null>(null);
   const tableScrollTop = useTableScrollTop(tableRef);
@@ -51,6 +51,7 @@ export const PortraitTable = observer(function PortraitView(props: ITableProps) 
                 parentLevel={0}
                 dataSetName={dataSetName}
                 getsFocusOnAddAttr={index === activeTableIndex}
+                selectionList={selectionList}
               />
             ))}
           </tbody>

--- a/src/hooks/useCodapState.tsx
+++ b/src/hooks/useCodapState.tsx
@@ -273,37 +273,25 @@ export const useCodapState = () => {
   };
 
   const updateSelection = async () => {
-    try {
-      const selectionListResult = await getSelectionList(selectedDataSetName);
-      if (selectionListResult.success) {
-        return selectionListResult.values;
+    if (selectedDataSet) {
+      try {
+        const selectionListResult = await getSelectionList(selectedDataSet.name);
+        if (selectionListResult.success) {
+          return selectionListResult.values;
+        }
+      } catch (error) {
+        // This will happen if not embedded in CODAP
+        console.warn("Not embedded in CODAP", error);
       }
-    } catch (error) {
-      // This will happen if not embedded in CODAP
-      console.warn("Not embedded in CODAP", error);
     }
   };
 
+  // This is used to select cases in CODAP when the user clicks on a MD plugin row in the table
+  // or when user navigates to a different case in the card view
   const selectCODAPCases = useCallback(async (caseIds: number[]) => {
     const caseIdsToStrings = caseIds.map(c => c.toString());
     if (selectedDataSet) {
      selectCases(selectedDataSet.name, caseIdsToStrings);
-    }
-  }, [selectedDataSet]);
-
-  const selectCasesInCodap = useCallback(async (caseIds: number[]) => {
-    const caseIdsToStrings = caseIds.map(c => c.toString());
-    console.log(" in selectCODAPCases", caseIdsToStrings);
-
-    if (selectedDataSet) {
-      // try {
-        await addCasesToSelection(selectedDataSet.name, caseIdsToStrings);
-        // check if the selection was successful
-        const selectionList = await getSelectionList(selectedDataSet.name);
-        console.log("selectionList", selectionList);
-        if (selectionList.success) {
-          console.log("Selected cases: ", selectionList.values);
-        }
     }
   }, [selectedDataSet]);
 
@@ -314,7 +302,7 @@ export const useCodapState = () => {
     }
   }, [interactiveState, updateInteractiveState]);
 
-  const listenForSelectionChanges = useCallback((callback: (notification: any) => void) => {
+  const listenForSelectionChanges = useCallback(async (callback: (notification: any) => void) => {
     if (selectedDataSet) {
       addDataContextChangeListener(selectedDataSet.name, callback);
     }

--- a/src/hooks/useCodapState.tsx
+++ b/src/hooks/useCodapState.tsx
@@ -16,7 +16,6 @@ import {
   updateAttribute,
   updateAttributePosition,
   updateCaseById,
-  addCasesToSelection
 } from "@concord-consortium/codap-plugin-api";
 import { runInAction } from "mobx";
 import { applySnapshot, unprotect } from "mobx-state-tree";

--- a/src/hooks/useCodapState.tsx
+++ b/src/hooks/useCodapState.tsx
@@ -359,7 +359,6 @@ export const useCodapState = () => {
     handleAddAttribute,
     updateTitle,
     selectCODAPCases,
-    getSelectionList,
     updateSelection,
     listenForSelectionChanges,
     handleCreateCollectionFromAttribute,

--- a/src/hooks/useCodapState.tsx
+++ b/src/hooks/useCodapState.tsx
@@ -301,7 +301,7 @@ export const useCodapState = () => {
     }
   }, [interactiveState, updateInteractiveState]);
 
-  const listenForSelectionChanges = useCallback(async (callback: (notification: any) => void) => {
+  const listenForSelectionChanges = useCallback((callback: (notification: any) => void) => {
     if (selectedDataSet) {
       addDataContextChangeListener(selectedDataSet.name, callback);
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,7 +81,8 @@ export interface ITableProps {
   activeTableIndex?: number;
   handleAddAttribute: (collection: ICollection, attrName: string, tableIndex: number) => Promise<void>;
   renameAttribute: (collectionName: string, attrId: number, oldName: string, newName: string) => Promise<void>;
-  codapSelectedCases?: ICaseObjCommon | undefined;
+  selectCases?: (caseIds: number[]) => Promise<void>;
+  codapSelectedCases?: ICaseObjCommon[] | undefined;
 }
 
 export interface IBoundingBox {

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,6 +81,7 @@ export interface ITableProps {
   activeTableIndex?: number;
   handleAddAttribute: (collection: ICollection, attrName: string, tableIndex: number) => Promise<void>;
   renameAttribute: (collectionName: string, attrId: number, oldName: string, newName: string) => Promise<void>;
+  codapSelectedCases?: ICaseObjCommon | undefined;
 }
 
 export interface IBoundingBox {

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,12 @@ export interface ICaseObjCommon {
   values: Values;
 }
 
+export interface ISelectedCase {
+  caseID: number;
+  collectionID: number;
+  collectionName: string;
+}
+
 export type Values = Map<string|number, any>;
 
 export interface ICaseObj extends ICaseObjCommon {
@@ -82,7 +88,7 @@ export interface ITableProps {
   handleAddAttribute: (collection: ICollection, attrName: string, tableIndex: number) => Promise<void>;
   renameAttribute: (collectionName: string, attrId: number, oldName: string, newName: string) => Promise<void>;
   selectCases?: (caseIds: number[]) => Promise<void>;
-  codapSelectedCases?: ICaseObjCommon[] | undefined;
+  selectionList?: ISelectedCase[];
 }
 
 export interface IBoundingBox {


### PR DESCRIPTION
User can:
- Select in CODAP and case highlights in MD plugin. Multiple selections with marquee select, shift, cmd/ctrl are supported.
- Select in MD plugin highlights case in CODAP. Multiple selection with cmd/ctrl is supported, but not shift and marquee select.
- Selected case in CODAP case card highlights case in MD plugin, and vice versa.
- Single click selects the case, double click enters into edit mode.