### PR TITLE
Ignore outside drop

### DIFF
--- a/src/components/nested-table-view/nested-table.scss
+++ b/src/components/nested-table-view/nested-table.scss
@@ -1,4 +1,5 @@
 .nestedTableWrapper {
   width: 95vw;
   margin: 0 auto;
+  height: 100vh;
 }

--- a/src/hooks/useCodapState.tsx
+++ b/src/hooks/useCodapState.tsx
@@ -19,7 +19,7 @@ import {
 } from "@concord-consortium/codap-plugin-api";
 import { runInAction } from "mobx";
 import { applySnapshot, unprotect } from "mobx-state-tree";
-import { getCases, getCollectionById, getDataSetCollections } from "../utils/apiHelpers";
+import { getCases, getCollectionById, getDataSetCollections, getPluginFrame, getPluginId } from "../utils/apiHelpers";
 import { ICollection, IDataSet, IProcessedCaseObj } from "../types";
 import { DataSetsModel, DataSetsModelType } from "../models/datasets";
 import { CollectionsModel, CollectionsModelSnapshot, CollectionsModelType } from "../models/collections";
@@ -341,6 +341,31 @@ export const useCodapState = () => {
     }
   };
 
+  const getPluginFrameRect = async () => {
+    const pluginId = await getPluginId();
+    if (!pluginId) {
+      console.error("Failed to retrieve pluginId");
+      return null;
+    }
+    const pluginFrame: any = await getPluginFrame(pluginId);
+    if (!pluginFrame) {
+      console.error("Failed to retrieve plugin frame");
+      return null;
+    }
+    const pluginFrameValues = pluginFrame.values;
+    console.log("pluginFrameValues", pluginFrameValues);
+    if (pluginFrameValues) {
+      return {
+        width: pluginFrameValues.dimensions.width,
+        height: pluginFrameValues.dimensions.height,
+        left: pluginFrameValues.position.left,
+        top: pluginFrameValues.position.top,
+        right: pluginFrameValues.position.left + pluginFrameValues.dimensions.width,
+        bottom: pluginFrameValues.position.top + pluginFrameValues.dimensions.height
+      };
+    }
+  };
+
   return {
     init,
     handleSelectSelf,
@@ -366,6 +391,7 @@ export const useCodapState = () => {
     editCaseValue,
     addAttributeToCollection,
     handleUpdateInteractiveState,
-    renameAttribute
+    renameAttribute,
+    getPluginFrameRect
   };
 };

--- a/src/hooks/useDraggableTable.ts
+++ b/src/hooks/useDraggableTable.ts
@@ -43,7 +43,15 @@ export const useDraggableTable = (options: IUseDraggableTableOptions) => {
 
   const handleDrop = useCallback((e: DragEndEvent) => {
     const { active, over } = e;
+      // Ensure the drop is within the `.nested-table-nestedTableWrapper`
+  const dropTarget = document.querySelector(".nested-table-nestedTableWrapper");
+  if (!dropTarget?.contains(over?.data?.current?.node as Node)) {
+    console.log("Drop occurred outside the nested table wrapper.");
+    setDragSide(undefined);
+    return;
+  }
     if (over) {
+      console.log("over", over);
       const source = getCollectionAndAttribute(active.data.current as IDndData);
       const overData = over.data.current;
       const target = getCollectionAndAttribute(overData as IDndData);

--- a/src/hooks/useDraggableTable.ts
+++ b/src/hooks/useDraggableTable.ts
@@ -5,9 +5,6 @@ import { useCodapState } from "./useCodapState";
 
 export type Side = "left"|"right";
 
-const topDiff = 120;
-const heightDiff = 25;
-
 type DraggableTableContextType = {
   handleDragOver: (clientX: number, over?: Over) => void
   dragSide: Side | undefined
@@ -48,27 +45,21 @@ export const useDraggableTable = (options: IUseDraggableTableOptions) => {
 
   const handleDrop = useCallback(async (e: DragEndEvent) => {
     const { active, over } = e;
-// FIXME: using the pluginframeRect from the plugin API doesn't return a consistent
-// top and height value. It differes from actual CODAP webview top and height values.
-    const pluginFrameRect = await getPluginFrameRect();
-    const pointerX = (e.activatorEvent as MouseEvent)?.clientX;
-    const pointerY = (e.activatorEvent  as MouseEvent)?.clientY;
 
-    console.log("e.activatorEvent:", {
-      x: pointerX,
-      y: pointerY,
-    });
-    const pluginFrameBottom = pluginFrameRect ? pluginFrameRect.top + pluginFrameRect.height - heightDiff  : 0;
+    const pluginFrameRect = await getPluginFrameRect();
+    const activatorEvent = e.activatorEvent as MouseEvent;
+    const pointerX = activatorEvent?.clientX + e.delta.x;
+    const pointerY = activatorEvent?.clientY + e.delta.y;
 
     const outsidePlugin = pluginFrameRect !== null && typeof pluginFrameRect === "object" &&
-                            (pointerX < pluginFrameRect.left || pointerX > pluginFrameRect.right ||
-                              pointerY < pluginFrameRect.top || pointerY > pluginFrameBottom);
-    console.log("outsidePlugin", outsidePlugin);
+                            (pointerX < 0 || pointerX > pluginFrameRect.width ||
+                              pointerY < 0 || pointerY > pluginFrameRect.height);
+
     // Plugin should ignore drops if it is outside the CODAP webview
     if (outsidePlugin) {
       return;
     }
-    
+
     if (over) {
       const source = getCollectionAndAttribute(active.data.current as IDndData);
       const overData = over.data.current;

--- a/src/hooks/useDraggableTable.ts
+++ b/src/hooks/useDraggableTable.ts
@@ -46,6 +46,12 @@ export const useDraggableTable = (options: IUseDraggableTableOptions) => {
   const handleDrop = useCallback(async (e: DragEndEvent) => {
     const { active, over } = e;
 
+    // FIXME: A little hacky, but it figures out mouse position based on where mousedown happened and
+    // the delta of current mouse position, and checks to see if it is bigger than the plugin iframe.
+    // We couldn't get the exact position of the mouse nor the plugin iframe, so everything is relative
+    // to the mousedown. Tried using screenX and screenY from both activatorEvent, winddow, and window.parent
+    // and the values for positions and dimensions didn't make sense.
+    // A better solution is to prevent calling this function if the mouse is outside the plugin iframe.
     const pluginFrameRect = await getPluginFrameRect();
     const activatorEvent = e.activatorEvent as MouseEvent;
     const pointerX = activatorEvent?.clientX + e.delta.x;

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -111,3 +111,30 @@ export function moveCodapDrag(context: string, attrTitle: string, mouseX: number
 export function endCodapDrag(context: string, attrTitle: string, mouseX: number, mouseY: number) {
   continueCodapDrag("dragEnd", context, attrTitle, mouseX, mouseY);
 }
+
+export async function getPluginId(): Promise<number | undefined> {
+  try {
+    const response: any = await codapInterface.sendRequest({
+      action: "get",
+      resource: "componentList"
+    });
+    if (response.success) {
+      const plugin = response.values.find((component: any) =>
+        component.type === "game" && component.title === "multidata-plugin"
+      );
+      return plugin?.id;
+    } else {
+      console.error("Error getting plugin ID:", response);
+    }
+  } catch(error) {
+    console.error("Error in getPluginId:", error);
+  }
+  return undefined;
+}
+
+export async function getPluginFrame(pluginId: number | string) {
+  return codapInterface.sendRequest({
+    action: "get",
+    resource: `component[${pluginId}]`
+  });
+}


### PR DESCRIPTION
A little hacky, but it figures out mouse position based on where mousedown happened and the delta of current mouse position, and checks to see if it is bigger than the plugin iframe.
We couldn't get the exact position of the mouse nor the plugin iframe, so everything is relative to the mousedown.